### PR TITLE
Added {} to URL paths and changed config section name

### DIFF
--- a/get_uptime.txt
+++ b/get_uptime.txt
@@ -1,4 +1,4 @@
-GET /uptime/s HTTP/1.1
+GET /uptime/{s} HTTP/1.1
 Accept-Language: en-US,en;q=0.5
 Accept-Encoding: gzip, deflate
 Connection: keep-alive

--- a/get_user.txt
+++ b/get_user.txt
@@ -1,4 +1,4 @@
-GET /user/admin1 HTTP/1.1
+GET /user/{admin1} HTTP/1.1
 Accept: application/json
 Content-Type: application/json
 X-Auth-Token: CALL_EXTERNAL|syntribos.extensions.vAPI.client:get_token|

--- a/vAPI.config
+++ b/vAPI.config
@@ -1,4 +1,4 @@
-[credentials]
+[vAPI]
 url=<url of the API>
 username=<username>
 password=<password>

--- a/vAPI/config.py
+++ b/vAPI/config.py
@@ -2,7 +2,7 @@ import cafe.engine.models.data_interfaces as data_interfaces
 
 
 class UserConfig(data_interfaces.ConfigSectionInterface):
-    SECTION_NAME = 'credentials'
+    SECTION_NAME = 'vAPI'
 
     @property
     def url(self):


### PR DESCRIPTION
Without the curly braces, Syntribos would not fuzz the URL paths.

Calling the config section "credentials" seemed too generic.